### PR TITLE
Adds report bugs link

### DIFF
--- a/public/images/feedback.svg
+++ b/public/images/feedback.svg
@@ -1,0 +1,4 @@
+<svg fill="#000000" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M0 0h24v24H0z" fill="none"/>
+    <path d="M20 2H4c-1.1 0-1.99.9-1.99 2L2 22l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-7 12h-2v-2h2v2zm0-4h-2V6h2v4z"/>
+</svg>

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -10,11 +10,13 @@
 
 @media only screen and (min-width: 600px) {
   .navbar__nav {
+    display: flex;
+    align-items: center;
     width: 10vw;
     position: fixed;
     left: -0.5vw;
     top: 0;
-    margin: 10rem 0 0;
+    margin: 0 2rem;
     background-color: $main-color;
   }
 }
@@ -31,7 +33,7 @@
 }
 
 .navbar__icon {
-  width: 10vw;
+  width: 8vw;
   margin: 0 3vw;
 }
 

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -42,14 +42,14 @@ body {
 
 @media only screen and (min-width: 600px) {
   body {
-    margin: 5vh 10vw;
+    margin: 5vh 10vw 0;
     transition: all 1s;
   }
 }
 
 @media only screen and (min-width: 769px) {
   body {
-    margin: 5vh 10vw;
+    margin: 5vh 10vw 0;
     transition: all 1s;
   }
 }

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -107,7 +107,9 @@ h1 {
   links page
 ***********************************************/
 
-.links__form, .links__submit, .links__input {
+.links__form,
+.links__submit,
+.links__input {
   font-size: $links-form-fontsize;
   padding: 0 2vw;
   text-align: center;
@@ -117,7 +119,8 @@ h1 {
   font-weight: 600;
 }
 
-.links__submit, .links__input {
+.links__submit,
+.links__input {
   display: block;
   height: 10vh;
   margin: 3vh 0;
@@ -234,37 +237,37 @@ h1 {
 }
 
 .report-section__error-message {
-   color: $error-message-color;
- }
+  color: $error-message-color;
+}
 
 /***********************************************
   github section
 ***********************************************/
 
 .report-section__website {
-    margin: 0 auto;
-    margin-top: 1em;
-    border: none;
-    background-color: white;
-    width: 90%;
-    max-width: 1600px;
+  margin: 0 auto;
+  margin-top: 1em;
+  border: none;
+  background-color: white;
+  width: 90%;
+  max-width: 1600px;
 }
 .report-section__website-link {
-    display: block;
+  display: block;
 }
- .report-section__info-item {
-   margin: 2vh 0;
- }
+.report-section__info-item {
+  margin: 2vh 0;
+}
 
- .report-section__info-title {
-   font-size: $report-subtitle-fontsize;
- }
+.report-section__info-title {
+  font-size: $report-subtitle-fontsize;
+}
 
- .report-section__info-description {
-   font-size: $report-description-fontsize;
- }
+.report-section__info-description {
+  font-size: $report-description-fontsize;
+}
 
- .report-section__calendar {
+.report-section__calendar {
   max-width: 92vw;
   margin: 5vh auto;
   overflow-x: scroll;
@@ -272,7 +275,6 @@ h1 {
 }
 
 @media only screen and (min-width: 600px) {
-
   .report-section__website {
     width: 100%;
   }
@@ -306,7 +308,7 @@ h1 {
 }
 
 .text-normal {
-  font-size: 1.2rem
+  font-size: 1.2rem;
 }
 
 /***********************************************
@@ -333,7 +335,7 @@ h1 {
   width: 90vw;
   margin-bottom: 7vh;
   padding: 1.5vh 1.5vw;
-  background-color: $highlight-color;;
+  background-color: $highlight-color;
   border: black solid 3px;
   border-radius: 2px;
   transition: all 1s;
@@ -367,9 +369,13 @@ h1 {
 .report-section__kata-item {
   font-size: $report-description-fontsize;
   padding: 3vh 3vw;
-  background-color: $highlight-color;;
+  background-color: $highlight-color;
   border: black solid 3px;
   border-radius: 2px;
   margin: 3vh 2vw;
   display: inline;
+}
+
+.footer {
+  padding: 1rem;
 }

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -375,7 +375,3 @@ h1 {
   margin: 3vh 2vw;
   display: inline;
 }
-
-.footer {
-  padding: 1rem;
-}

--- a/views/partials/navbar.hbs
+++ b/views/partials/navbar.hbs
@@ -25,5 +25,10 @@
         <img class="navbar__icon" src="/images/meetup.svg" alt="Meetup">
       </a>Meetup
     </li>
+    <li class="navbar__item">
+      <a class="navbar__link" target="_blank" href="https://github.com/foundersandcoders/prereq-check/issues/new?labels=site-feedback">
+        <img class="navbar__icon" src="/images/feedback.svg" alt="Feedback">
+      </a>Feedback
+    </li>
   </ul>
 </nav>

--- a/views/partials/reportBug.hbs
+++ b/views/partials/reportBug.hbs
@@ -1,4 +1,4 @@
 <footer class="footer">
   Found a bug or have some feedback?
-  <a target="_blank" href="https://github.com/foundersandcoders/prereq-check/issues/new">Raise an issue on GitHub</a>
+  <a target="_blank" href="https://github.com/foundersandcoders/prereq-check/issues/new?labels=site-feedback">Raise an issue on GitHub</a>
 </footer>

--- a/views/partials/reportBug.hbs
+++ b/views/partials/reportBug.hbs
@@ -1,4 +1,4 @@
 <footer class="footer">
-  Found a bug?
-  <a href="https://github.com/ameliejyc/prereq-check/issues">Raise an issue on GitHub</a>
+  Found a bug or have some feedback?
+  <a target="_blank" href="https://github.com/foundersandcoders/prereq-check/issues/new">Raise an issue on GitHub</a>
 </footer>

--- a/views/partials/reportBug.hbs
+++ b/views/partials/reportBug.hbs
@@ -1,4 +1,0 @@
-<footer class="footer">
-  Found a bug or have some feedback?
-  <a target="_blank" href="https://github.com/foundersandcoders/prereq-check/issues/new?labels=site-feedback">Raise an issue on GitHub</a>
-</footer>

--- a/views/partials/reportBug.hbs
+++ b/views/partials/reportBug.hbs
@@ -1,0 +1,4 @@
+<footer class="footer">
+  Found a bug?
+  <a href="https://github.com/ameliejyc/prereq-check/issues">Raise an issue on GitHub</a>
+</footer>

--- a/views/report.hbs
+++ b/views/report.hbs
@@ -4,4 +4,4 @@
 {{>freecodecamp}}
 {{>codewars}}
 {{>meetup}}
-
+{{>reportBug}}

--- a/views/report.hbs
+++ b/views/report.hbs
@@ -4,4 +4,3 @@
 {{>freecodecamp}}
 {{>codewars}}
 {{>meetup}}
-{{>reportBug}}


### PR DESCRIPTION
fixes #101 

I have added a link to open a new issue in this repository. Currently this is located in the footer of the report. I'm not sure if this is the best placement because a lot of users won't scroll this far down. Especially if they haven't been to meetups as this is the final section? It could be part of the navbar  @sofer thoughts on this?

I think it is possible to specify the new issue to have a label called `site-feedback` (or something similar) so its easier to see which issues were raised from the site as well.

**UPDATE:**
- added the label to the link
- changed the link to be part of the navbar for greater visibility (screenshots below)

![feedback-nav](https://user-images.githubusercontent.com/25408167/38193426-f34f54d4-3669-11e8-9aac-95df2f2c2959.gif)
![feedback-nav-mobile](https://user-images.githubusercontent.com/25408167/38193429-f5b368c8-3669-11e8-99d3-5cd0b588420b.gif)
